### PR TITLE
Feature: Elementus-to-Lyra Data Adapter

### DIFF
--- a/Plugins/GameFeatures/CraterInventory/Source/CraterInventoryRuntime/Private/ElementusItemData_LyraIntegration.cpp
+++ b/Plugins/GameFeatures/CraterInventory/Source/CraterInventoryRuntime/Private/ElementusItemData_LyraIntegration.cpp
@@ -1,0 +1,2 @@
+#include "ElementusItemData_LyraIntegration.h"
+

--- a/Plugins/GameFeatures/CraterInventory/Source/CraterInventoryRuntime/Public/ElementusItemData_LyraIntegration.h
+++ b/Plugins/GameFeatures/CraterInventory/Source/CraterInventoryRuntime/Public/ElementusItemData_LyraIntegration.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Management/ElementusInventoryData.h"
+#include "ElementusItemData_LyraIntegration.generated.h"
+/**
+ * @brief  Elementus Item Data class with Lyra Inventory integration.
+ *
+ * @description This class extends UElementusItemData to include a
+ * soft reference to a Lyra Inventory Item Definition.
+ * @see UElementusItemData
+ */
+UCLASS(BlueprintType, Category = "Crater Inventory | Data")
+class CRATERINVENTORY_API UElementusItemData_LyraIntegration : public UElementusItemData
+{
+public:
+		GENERATED_BODY()
+protected:
+	// Soft reference to a Lyra Inventory Item Definition
+	UPROPERTY(
+		EditAnywhere,
+		BlueprintReadOnly,
+		Category = "Crater Inventory | Lyra Integration"
+		)
+	TSoftClassPtr<class ULyraInventoryItemDefinition> LyraItemDefinition;
+		
+};

--- a/Plugins/GameFeatures/CraterInventory/Source/CraterInventoryRuntime/Public/ElementusItemData_LyraIntegration.h
+++ b/Plugins/GameFeatures/CraterInventory/Source/CraterInventoryRuntime/Public/ElementusItemData_LyraIntegration.h
@@ -13,15 +13,14 @@
 UCLASS(BlueprintType, Category = "Crater Inventory | Data")
 class CRATERINVENTORY_API UElementusItemData_LyraIntegration : public UElementusItemData
 {
+	GENERATED_BODY()
+
 public:
-		GENERATED_BODY()
-protected:
 	// Soft reference to a Lyra Inventory Item Definition
 	UPROPERTY(
 		EditAnywhere,
 		BlueprintReadOnly,
 		Category = "Crater Inventory | Lyra Integration"
-		)
+	)
 	TSoftClassPtr<class ULyraInventoryItemDefinition> LyraItemDefinition;
-		
 };

--- a/Plugins/UEElementusInventory/Source/ElementusInventory/Public/Management/ElementusInventoryData.h
+++ b/Plugins/UEElementusInventory/Source/ElementusInventory/Public/Management/ElementusInventoryData.h
@@ -121,7 +121,7 @@ struct FElementusItemInfo
 };
 
 UCLASS(NotBlueprintable, NotPlaceable, Category = "Elementus Inventory | Classes | Data")
-class ELEMENTUSINVENTORY_API UElementusItemData final : public UPrimaryDataAsset
+class ELEMENTUSINVENTORY_API UElementusItemData : public UPrimaryDataAsset
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
### Description
This PR introduces the Elementus-to-Lyra Data Adapter, bridging the Elementus lightweight inventory system with Lyra's fragment-based itemization.

### Changes
- Added a new Data Asset type inheriting from `UElementusItemData`.
- Included a `TSoftClassPtr` reference to `ULyraInventoryItemDefinition`.
- Ensured the asset is viewable and editable in the Unreal Editor.

### Acceptance Criteria
- The new Data Asset type exists and meets the requirements.
- The adapter allows Elementus items to reference Lyra Inventory Definitions.
- Items can be stored in the Elementus database and spawn Lyra Equipment actors when equipped.

### Related Epic
Parent branch: `epic/data-architecture-the-bridge`

### Related Issue
Closes #3